### PR TITLE
build: simplify JVM target specification

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,11 +20,6 @@ tasks.withType<ShadowJar> {
     archiveClassifier = null
 }
 
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
-
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.JVM_11


### PR DESCRIPTION
These configurations are already set when using `kotlin.compilerOptions.jvmTarget`