### PR TITLE
fixed test: integration tests now prefer using local jar

### DIFF
--- a/examples/with_local_plugin_repository/settings.gradle.kts
+++ b/examples/with_local_plugin_repository/settings.gradle.kts
@@ -1,10 +1,10 @@
 pluginManagement {
     repositories {
-        mavenCentral()
-        gradlePluginPortal()
         mavenLocal {
             url = uri("../../.local-plugin-repository")
         }
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 


### PR DESCRIPTION
The order of the repositories matters, first repositories are scanned first.
The integration tests were using the now published plugin instead of the locally created plugin