### PR TITLE
maven-plugin: added configuration for publishing the plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 11
+          gpg-private-key: ${{ secrets.gpg_key }}
+          gpg-passphrase: ${{ secrets.gpg_passphrase }}
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2.4.2
@@ -46,7 +48,7 @@ jobs:
       - name: Build Maven Plugin
         run: |
           cd maven-plugin
-          mvn clean install --batch-mode 
+          mvn clean install -Dgpg.passphrase='${{ secrets.gpg_passphrase }}' --batch-mode 
 
       - name: Integration tests with maven plugin
         run: |

--- a/examples/maven_project_example/pom.xml
+++ b/examples/maven_project_example/pom.xml
@@ -48,42 +48,12 @@
     </dependencies>
 
     <build>
-        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
-
-        <plugins>
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.9.20</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-
         <pluginManagement>
             <plugins>
                 <plugin>
                     <groupId>io.atlasgo</groupId>
                     <artifactId>hibernate-provider-maven-plugin</artifactId>
                     <version>0.1</version>
-                    <executions>
-                        <execution>
-                            <id>schema-using-postgresq-properties</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>schema</goal>
-                            </goals>
-                            <configuration>
-                                <properties>postgresql.properties</properties>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/hibernate-provider/build.gradle.kts
+++ b/hibernate-provider/build.gradle.kts
@@ -44,6 +44,7 @@ tasks.jar {
     archiveBaseName.set(rootProject.name)
 }
 
+
 publishing {
     publications {
         create<MavenPublication>("hibernate-provider") {
@@ -59,13 +60,13 @@ publishing {
                         url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
                     }
                 }
-//                developers {
-//                    developer {
-//                        id = "johnd"
-//                        name = "John Doe"
-//                        email = "john.doe@example.com"
-//                    }
-//                }
+                developers {
+                    developer {
+                        id = "Ariga it"
+                        name = "Ariga it"
+                        email = "it@ariga.io"
+                    }
+                }
                 scm {
                     connection = "scm:git:git://github.com/ariga/atlas-provider-hibernate.git"
                     developerConnection = "scm:git:ssh://github.com/ariga/atlas-provider-hibernate.git"
@@ -74,7 +75,13 @@ publishing {
             }
         }
     }
+
     repositories {
+        maven {
+            name = "ossrh"
+            credentials(PasswordCredentials::class)
+            url = uri("https://s01.oss.sonatype.org/content/groups/staging/")
+        }
         maven {
             name = "localPluginRepository"
             url = uri("../.local-plugin-repository")

--- a/hibernate-provider/build.gradle.kts
+++ b/hibernate-provider/build.gradle.kts
@@ -64,7 +64,7 @@ publishing {
                     developer {
                         id = "Ariga"
                         name = "Ariga"
-                        email = "it@ariga.io"
+                        email = "it@atlasgo.io"
                     }
                 }
                 scm {

--- a/hibernate-provider/build.gradle.kts
+++ b/hibernate-provider/build.gradle.kts
@@ -62,8 +62,8 @@ publishing {
                 }
                 developers {
                     developer {
-                        id = "Ariga it"
-                        name = "Ariga it"
+                        id = "Ariga"
+                        name = "Ariga"
                         email = "it@ariga.io"
                     }
                 }

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -27,7 +27,7 @@
     <developers>
         <developer>
             <name>Ariga</name>
-            <email>it@ariga.io</email>
+            <email>it@atlasgo.io</email>
             <organization>Ariga</organization>
             <organizationUrl>https://atlasgo.cloud/</organizationUrl>
         </developer>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -6,7 +6,8 @@
     <groupId>io.atlasgo</groupId>
     <artifactId>hibernate-provider-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>0.1</version>
+    <version>0.2-SNAPSHOT</version>
+    <description>Atlas Hibernate schema provider</description>
 
     <name>hibernate-provider-maven-plugin Maven Mojo</name>
     <url>https://github.com/ariga/atlas-provider-hibernate</url>
@@ -15,6 +16,28 @@
         <maven.compiler.target>11</maven.compiler.target>
         <maven.compiler.source>11</maven.compiler.source>
     </properties>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Ariga</name>
+            <email>it@ariga.io</email>
+            <organization>Ariga</organization>
+            <organizationUrl>https://atlasgo.cloud/</organizationUrl>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/ariga/atlas-provider-hibernate.git</connection>
+        <developerConnection>scm:git:ssh://github.com:ariga/atlas-provider-hibernate.git</developerConnection>
+        <url>http://github.com/ariga/atlas-provider-hibernate/tree/master</url>
+    </scm>
 
     <dependencies>
         <dependency>
@@ -54,6 +77,17 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <build>
         <plugins>
             <plugin>
@@ -74,6 +108,65 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <configuration>
+                            <keyname>${gpg.keyname}</keyname>
+                            <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.13</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>


### PR DESCRIPTION
Note: Publishing the library itself is incomplete and requires adding signing of the package for it to work.
Signing needs to be done manually at the moment and does not work on github actions without additional changes