### PR TITLE
update deprecated hibernate properties: hibernate.temp.use_jdbc_metadata_defaults to hibernate.boot.allow_jdbc_metadata_access

### DIFF
--- a/hibernate-provider/src/main/kotlin/HibernateProvider.kt
+++ b/hibernate-provider/src/main/kotlin/HibernateProvider.kt
@@ -114,6 +114,7 @@ class PrintSchemaCommand: CliktCommand() {
             } ?: throw RuntimeException("Unable to load properties file '$properties', is it in the classpath?")
         }
         mapOf(
+            "hibernate.temp.use_jdbc_metadata_defaults" to false, // deprecated from hibernate 6.5
             "hibernate.boot.allow_jdbc_metadata_access" to false,
             AvailableSettings.SCHEMA_MANAGEMENT_TOOL to ConsoleSchemaManagementTool(HibernateSchemaManagementTool(), enableTableGenerator),
             AvailableSettings.CONNECTION_PROVIDER to UserSuppliedConnectionProviderImpl(),

--- a/hibernate-provider/src/main/kotlin/HibernateProvider.kt
+++ b/hibernate-provider/src/main/kotlin/HibernateProvider.kt
@@ -114,7 +114,7 @@ class PrintSchemaCommand: CliktCommand() {
             } ?: throw RuntimeException("Unable to load properties file '$properties', is it in the classpath?")
         }
         mapOf(
-            "hibernate.temp.use_jdbc_metadata_defaults" to false,
+            "hibernate.boot.allow_jdbc_metadata_access" to false,
             AvailableSettings.SCHEMA_MANAGEMENT_TOOL to ConsoleSchemaManagementTool(HibernateSchemaManagementTool(), enableTableGenerator),
             AvailableSettings.CONNECTION_PROVIDER to UserSuppliedConnectionProviderImpl(),
         ).forEach {


### PR DESCRIPTION
![스크린샷 2024-06-18 오전 1 24 17](https://github.com/ariga/atlas-provider-hibernate/assets/4957065/d7028f09-88a5-4283-9023-deae9033ed5d)

cause: 
hibernate provider fails with: executing statement: "HHH90000021: Encountered deprecated setting [hibernate.temp.use_jdbc_metadata_defaults], use [hibernate.boot.allow_jdbc_metadata_access] instead

fixed:
hibernate.temp.use_jdbc_metadata_defaults -> hibernate.boot.allow_jdbc_metadata_access